### PR TITLE
refactor(parser): improve error handling and extensibility

### DIFF
--- a/parser/msgid.go
+++ b/parser/msgid.go
@@ -3,8 +3,6 @@ package parser
 import (
 	"fmt"
 	"strings"
-
-	"github.com/Tom5521/xgotext/flags"
 )
 
 type Location struct {
@@ -19,7 +17,7 @@ type Translation struct {
 	Locations []Location
 }
 
-func (t Translation) String() string {
+func (t Translation) Format(nplurals uint) string {
 	var builder strings.Builder
 
 	fprintfln := func(format string, args ...any) {
@@ -42,7 +40,7 @@ func (t Translation) String() string {
 
 	if t.Plural != "" {
 		fprintfln("msgid_plural %s", plural)
-		for i := range flags.Nplurals {
+		for i := range nplurals {
 			fprintfln(`msgstr[%d] ""`, i)
 		}
 	} else {


### PR DESCRIPTION
- Enhanced error reporting in `ParseTranslations` and `processMethod` with detailed context.
- Introduced `errs []error` return type in `ParseTranslations` and `Parse` to aggregate errors.
- Modified `extractArgument` to return errors for better validation.
- Removed unused dependencies `flags` and `color` for cleaner code.
- Adjusted `Translation.Format` to use dynamic `nplurals` argument.
- Added exclusion logic in `Parser` with tracking of processed paths.